### PR TITLE
[기능 추가] 푸터 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Cambay&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Cambay&family=Noto+Sans+KR&display=swap"
       rel="stylesheet"
     />
     <title>Vite + React + TS</title>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,21 @@
+const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="hidden md:block bg-light-gray text-dusty-black text-center dark:text-dusty-gray md:py-14 xl:py-[70px] font-noto-sans">
+      <section>
+        <p className="md:p-2 xl:p-5 text-xl font-bold">일인칭서재</p>
+        <p className="md:p-[2px] xl:p-1">
+          <span className="font-bold">Contact</span>{' '}
+          firstpersonlibrary@gmail.com
+        </p>
+        <p className="md:p-[2px] xl:p-1">
+          <span className="font-bold">Copyright</span> © {currentYear}{' '}
+          일인칭서재 All rights reserved
+        </p>
+      </section>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,7 @@ export default {
       },
       fontFamily: {
         cambay: ['Cambay', 'sans-serif'],
+        'noto-sans': ['Noto Sans KR', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## 작업 내용
1. 푸터에 사용될 Regualr 400 noto Sans KR 글꼴 추가합니다. 
 1-1. index.html 파일에 <link> 태그로 import 합니다. 
 1-2. tailwind.config.js 파일 fontFamily에 noto-sans로 등록합니다.
3. 올해 연도는 빌드인 Date 객체 메소드 getFullYear로 명시합니다.

## 결과 화면
![266130485-cfc7c678-a039-40e4-846b-cc7ac8c57fe0](https://github.com/first-person-library/first-person-library/assets/97335934/9ffa1547-9076-4899-84d0-b566adaaa3f4)
