### PR TITLE
[기능 추가] 모달 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <article id="modal-root"></article>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import { Outlet } from 'react-router-dom';
+import { ModalProvider } from './contexts/ModalContext';
 import Header from './components/Header/Header';
 
 function App() {
   return (
     <>
       <Header />
-      <Outlet />
+      <ModalProvider>
+        <Outlet />
+      </ModalProvider>
     </>
   );
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Portal from './Portal';
+
+type Props = {
+  isOpen: boolean;
+  children: React.ReactNode;
+  onClose: () => void;
+  selector?: string;
+};
+
+export default function Modal({
+  isOpen,
+  children,
+  onClose,
+  selector = '#modal-root',
+}: Props) {
+  return (
+    <>
+      {isOpen ? (
+        <Portal selector={selector}>
+          <div className="fixed z-50 inset-0 overflow-hidden flex items-center justify-center">
+            <div
+              onClick={onClose}
+              className="fixed inset-0 bg-modal-black opacity-50"
+            ></div>
+            <div className="md:max-w-[720px] lg:max-w-3xl relative w-full">
+              {children}
+            </div>
+          </div>
+        </Portal>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/Modal/Portal.tsx
+++ b/src/components/Modal/Portal.tsx
@@ -1,0 +1,13 @@
+import { createPortal } from 'react-dom';
+
+type Props = {
+  children: React.ReactNode;
+  selector?: string;
+};
+
+export default function Portal({ children, selector }: Props) {
+  const rootEl = selector && document.querySelector(selector);
+  return (
+    <div>{rootEl ? createPortal(children, rootEl) : children}</div>
+  );
+}

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,0 +1,32 @@
+import { ReactNode, useState, createContext, useContext } from 'react';
+
+type ModalContext = {
+  isOpen: boolean;
+  handleOpen: () => void;
+  handleClose: () => void;
+};
+
+type Props = {
+  children: ReactNode;
+};
+
+const ModalContext = createContext<ModalContext>({
+  isOpen: false,
+  handleOpen: () => {},
+  handleClose: () => {},
+});
+
+export function ModalProvider({ children }: Props) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return (
+    <ModalContext.Provider value={{ isOpen, handleOpen, handleClose }}>
+      {children}
+    </ModalContext.Provider>
+  );
+}
+
+export const useModal = () => useContext(ModalContext);


### PR DESCRIPTION
## 작업 내용
1. 외부 DOM에 엘리먼트를 렌더링하기 위해 포탈(Portal)을 사용합니다.
2. 모달 렌더링하기 위해 index.html에 `#modal-root`를 명시합니다.
3. Portal.tsx은 추상화해주기 위해 DOM 엘리먼트(selector)를 props로 내려받습니다.
4. Modal.tsx에서 Dim과 Overlay 스타일링을 지정합니다. selector 초기값으로 `#modal-root` 선언합니다.
5. 모달은 프로젝트 전반에서 사용되기 때문에 전역 상태 관리를 위해 contextAPI로 상태를 공유합니다.

## 결과 화면
![266130653-074a50c3-fefb-4ff3-b72b-af696c0cd133](https://github.com/first-person-library/first-person-library/assets/97335934/b85f63d9-374f-4ec6-9618-71245cacef21)

