### PR TITLE
[기능 추가] 문의하기 구현, 회사 정보 전역 컨텍스트 추가, 선언 일관성 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,19 @@
 import { Outlet } from 'react-router-dom';
 import { ModalProvider } from './contexts/ModalContext';
+import { OfficialInfoProvider } from './contexts/OfficialInfoContext';
 import Header from './components/Header/Header';
 import Footer from './components/Footer/Footer';
 
 function App() {
   return (
     <>
-      <Header />
-      <ModalProvider>
-        <Outlet />
-      </ModalProvider>
-      <Footer />
+      <OfficialInfoProvider>
+        <Header />
+        <ModalProvider>
+          <Outlet />
+        </ModalProvider>
+        <Footer />
+      </OfficialInfoProvider>
     </>
   );
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,21 +1,21 @@
-const Footer = () => {
+import { useOfficialInfo } from '../../contexts/OfficialInfoContext';
+
+export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const { officialName, officialEmail } = useOfficialInfo();
 
   return (
     <footer className="hidden md:block bg-bright-gray text-dusty-black text-center dark:text-dusty-gray md:py-14 xl:py-[70px] font-noto-sans">
       <section>
-        <p className="md:p-2 xl:p-5 text-xl font-bold">일인칭서재</p>
+        <p className="md:p-2 xl:p-5 text-xl font-bold">{officialName}</p>
         <p className="md:p-[2px] xl:p-1">
-          <span className="font-bold">Contact</span>{' '}
-          firstpersonlibrary@gmail.com
+          <span className="font-bold">Contact</span> {officialEmail}
         </p>
         <p className="md:p-[2px] xl:p-1">
-          <span className="font-bold">Copyright</span> © {currentYear}{' '}
-          일인칭서재 All rights reserved
+          <span className="font-bold">Copyright</span> © {currentYear}
+          {officialName} All rights reserved
         </p>
       </section>
     </footer>
   );
-};
-
-export default Footer;
+}

--- a/src/components/Header/ProfileDropdown.tsx
+++ b/src/components/Header/ProfileDropdown.tsx
@@ -1,29 +1,42 @@
 import { Link } from 'react-router-dom';
+import { useOfficialInfo } from '../../contexts/OfficialInfoContext';
 import Icon from '../UI/Icon';
 
-const ProfileDropdown = () => (
-  <ul className="absolute right-0 top-full py-3 w-40 rounded-lg bg-white z-40 shadow-lg">
-    <li className="dropdown-li">
-      <Icon
-        src="/icon/mycomment.png"
-        alt="My 코멘트"
-        className="icon w-6 mr-2"
-      />
-      <Link to="/">My 코멘트</Link>
-    </li>
-    <li className="dropdown-li">
-      <Icon src="/icon/settings.png" alt="내 정보" className="icon w-6 mr-2" />
-      <Link to="/">내 정보</Link>
-    </li>
-    <li className="dropdown-li">
-      <Icon src="/icon/help.png" alt="문의하기" className="icon w-6 mr-2" />
-      <Link to="/">문의하기</Link>
-    </li>
-    <li className="dropdown-li">
-      <Icon src="/icon/logout.png" alt="로그아웃" className="icon w-6 mr-2" />
-      <Link to="/">로그아웃</Link>
-    </li>
-  </ul>
-);
+export default function ProfileDropdown() {
+  const { officialEmail } = useOfficialInfo();
 
-export default ProfileDropdown;
+  return (
+    <ul className="absolute right-0 top-full py-3 w-40 rounded-lg bg-white z-40 shadow-lg">
+      <li className="dropdown-li">
+        <Icon
+          src="/icon/mycomment.png"
+          alt="My 코멘트"
+          className="icon w-6 mr-2"
+        />
+        <Link to="/">My 코멘트</Link>
+      </li>
+      <li className="dropdown-li">
+        <Icon
+          src="/icon/settings.png"
+          alt="내 정보"
+          className="icon w-6 mr-2"
+        />
+        <Link to="/">내 정보</Link>
+      </li>
+      <li className="dropdown-li">
+        <Icon src="/icon/help.png" alt="문의하기" className="icon w-6 mr-2" />
+        <a
+          href={`https://mail.google.com/mail/?view=cm&fs=1&to=${officialEmail}`}
+          target="_blank"
+          rel="nooperner noreferrer"
+        >
+          문의하기
+        </a>
+      </li>
+      <li className="dropdown-li">
+        <Icon src="/icon/logout.png" alt="로그아웃" className="icon w-6 mr-2" />
+        <Link to="/">로그아웃</Link>
+      </li>
+    </ul>
+  );
+}

--- a/src/contexts/OfficialInfoContext.tsx
+++ b/src/contexts/OfficialInfoContext.tsx
@@ -1,0 +1,30 @@
+import { ReactNode, createContext, useContext } from 'react';
+
+type OfficialInfoContextType = {
+  officialName: string;
+  officialEmail: string;
+};
+
+type OfficialInfoProviderProps = {
+  children: ReactNode;
+};
+
+const OfficialInfoContext = createContext<OfficialInfoContextType>({
+  officialName: '일인칭서재',
+  officialEmail: 'firstpersonlibrary@gmail.com',
+});
+
+export function OfficialInfoProvider({ children }: OfficialInfoProviderProps) {
+  return (
+    <OfficialInfoContext.Provider
+      value={{
+        officialName: '일인칭서재',
+        officialEmail: 'firstpersonlibrary@gmail.com',
+      }}
+    >
+      {children}
+    </OfficialInfoContext.Provider>
+  );
+}
+
+export const useOfficialInfo = () => useContext(OfficialInfoContext);


### PR DESCRIPTION
## 작업 내용
- 프로필 이미지를 클릭하여 드롭다운 항목에서 '문의하기'를 선택하면 사용자가 메일 클라이언트를 통해 이메일을 보낼 수 있는 링크를 구현하였습니다.
- 기존에 하드코딩되어 있던 회사명과 회사 이메일을 전역으로 관리하기 위해 Context API를 사용하여 관련 코드를 추가했습니다.
- Footer.tsx 및 ProfileDropdown.tsx 파일의 컴포넌트 선언을 함수 표현식에서 함수 선언문으로 수정하여 전체적인 코드 일관성을 향상시켰습니다.

## 추가 정보
사용자의 기본 메일 클라이언트에서 새 메일 창이 열리게 됩니다. 이 메일 창에 이미 일인칭서재 수신인 이메일 주소가 입력되어 있어 사용자가 문의사항을 작성하고 보낼 수 있게 해 줍니다.